### PR TITLE
fix: onConnect does not follow callback pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "pull-ws": "^3.2.8"
   },
   "devDependencies": {
-    "aegir": "^9.0.1",
+    "aegir": "^9.1.1",
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
     "interface-transport": "^0.3.3",

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ module.exports = class WebSockets {
     log('dialing %s', url)
     const socket = connect(url, {
       binary: true,
-      onConnect: callback
+      onConnect: () => callback
     })
 
     const conn = new Connection(socket)


### PR DESCRIPTION
If the callback was passed to dial, we would get a funny error
![image](https://cloud.githubusercontent.com/assets/1211152/20109319/7a08810a-a5d7-11e6-923b-4970ff3210bf.png)
