### PR TITLE
Use lodash.includes instead of the deprecated lodash.contains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,7 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
+# Vim editor swap files
+*.swp
+
 dist

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/libp2p/js-libp2p-websockets#readme",
   "dependencies": {
     "interface-connection": "^0.3.0",
-    "lodash.contains": "^2.4.3",
+    "lodash.includes": "^4.3.0",
     "mafmt": "^2.1.2",
     "pull-ws": "^3.2.8"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const connect = require('pull-ws/client')
 const mafmt = require('mafmt')
-const contains = require('lodash.contains')
+const includes = require('lodash.includes')
 const Connection = require('interface-connection').Connection
 const debug = require('debug')
 const log = debug('libp2p:websockets:dialer')
@@ -51,7 +51,7 @@ module.exports = class WebSockets {
     }
 
     return multiaddrs.filter((ma) => {
-      if (contains(ma.protoNames(), 'ipfs')) {
+      if (includes(ma.protoNames(), 'ipfs')) {
         ma = ma.decapsulate('ipfs')
       }
       return mafmt.WebSockets.matches(ma)

--- a/src/listener.js
+++ b/src/listener.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Connection = require('interface-connection').Connection
-const contains = require('lodash.contains')
+const includes = require('lodash.includes')
 
 // const IPFS_CODE = 421
 
@@ -28,7 +28,7 @@ module.exports = (options, handler) => {
     cb = cb || (() => {})
     listeningMultiaddr = ma
 
-    if (contains(ma.protoNames(), 'ipfs')) {
+    if (includes(ma.protoNames(), 'ipfs')) {
       ma = ma.decapsulate('ipfs')
     }
 


### PR DESCRIPTION
I started looking at ipfs/js-ipfs#632, and traced those deprecation warnings largely to this repo.  The lodash.contains dependency is easy to fix.  The others are all coming from the most recent `gulp` module, so will have to be addressed there.