### PR TITLE
Pass through errors from pull-ws onConnect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ class WebSockets {
     log('dialing %s', url)
     const socket = connect(url, {
       binary: true,
-      onConnect: () => callback()
+      onConnect: (err) => callback(err)
     })
 
     const conn = new Connection(socket)


### PR DESCRIPTION
Not passing errors meant that failed websocket connections were being treated as successful dials.