### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "interface-connection": "~0.3.2",
     "lodash.includes": "^4.3.0",
-    "mafmt": "^2.1.8",
+    "mafmt": "^3.0.1",
     "pull-ws": "^3.2.9"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "dirty-chai": "^2.0.1",
     "gulp": "^3.9.1",
     "interface-transport": "~0.3.5",
-    "multiaddr": "^2.3.0",
+    "multiaddr": "^3.0.1",
     "pre-commit": "^1.2.2",
     "pull-goodbye": "0.0.2",
     "pull-stream": "^3.6.0"


### PR DESCRIPTION
Trying to fix an error in IPFS 0.26.0 that seems to come from a leaking old dependency

```
protocols-table.js:17 Uncaught Error: no protocol with name: p2p-webrtc-star
    at Protocols (protocols-table.js:17)
    at stringToStringTuples (codec.js:45)
    at stringToBuffer (codec.js:170)
    at Object.fromString (codec.js:178)
    at new Multiaddr (index.js:39)
    at Multiaddr (index.js:27)
    at WebRTCStar._peerDiscovered (index.js:223)
    at Socket.Emitter.emit (index.js:133)
    at Socket.onevent (socket.js:270)
    at Socket.onpacket (socket.js:228)
```