### PR TITLE
chore: add discourse badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: node_js
+cache: npm
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+
+os:
+  - linux
+  - osx
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - stage: check
+      script:
+        - npx aegir commitlint --travis
+        - npx aegir dep-check -- -i wrtc -i electron-webrtc
+        - npm run lint
+
+    - stage: test
+      name: chrome
+      addons:
+        chrome: stable
+      script:
+        - npx aegir test -t browser
+
+    - stage: test
+      name: firefox
+      addons:
+        firefox: latest
+      script:
+        - npx aegir test -t browser -- --browsers FirefoxHeadless
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 [![Coverage Status](https://coveralls.io/repos/github/libp2p/js-libp2p-websockets/badge.svg?branch=master)](https://coveralls.io/github/libp2p/js-libp2p-websockets?branch=master)
 [![Travis CI](https://travis-ci.org/libp2p/js-libp2p-websockets.svg?branch=master)](https://travis-ci.org/libp2p/js-libp2p-websockets)
 [![Circle CI](https://circleci.com/gh/libp2p/js-libp2p-websockets.svg?style=svg)](https://circleci.com/gh/libp2p/js-libp2p-websockets)

--- a/package.json
+++ b/package.json
@@ -42,19 +42,19 @@
   "dependencies": {
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
-    "interface-connection": "~0.3.2",
-    "mafmt": "^6.0.4",
+    "interface-connection": "~0.3.3",
+    "mafmt": "^6.0.7",
     "multiaddr-to-uri": "^4.0.1",
     "pull-ws": "hugomrdias/pull-ws#fix/bundle-size"
   },
   "devDependencies": {
-    "aegir": "^18.0.3",
-    "chai": "^4.1.2",
+    "aegir": "^18.2.1",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "interface-transport": "~0.3.6",
-    "multiaddr": "^6.0.3",
+    "interface-transport": "~0.3.7",
+    "multiaddr": "^6.0.6",
     "pull-goodbye": "0.0.2",
-    "pull-stream": "^3.6.7"
+    "pull-stream": "^3.6.9"
   },
   "contributors": [
     "Chris Campbell <christopher.d.campbell@gmail.com>",

--- a/test/node.js
+++ b/test/node.js
@@ -253,7 +253,8 @@ describe('dial', () => {
     })
   })
 
-  describe('ip6', () => {
+  // TODO: https://github.com/libp2p/js-libp2p-websockets/issues/84
+  describe.skip('ip6', () => {
     let ws
     let listener
     const ma = multiaddr('/ip6/::1/tcp/9091')


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated and Travis CI added and `ipv6` tests were skipped [libp2p/js-libp2p-websockets#84](https://github.com/libp2p/js-libp2p-websockets/issues/84)