### PR TITLE
chore: update multiaddr-to-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "debug": "^4.1.1",
     "interface-connection": "~0.3.3",
     "mafmt": "^6.0.7",
-    "multiaddr-to-uri": "^4.0.1",
+    "multiaddr-to-uri": "^5.0.0",
     "pull-ws": "hugomrdias/pull-ws#fix/bundle-size"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds support for implicit HTTP multiaddrs added in https://github.com/multiformats/js-multiaddr-to-uri/pull/7

cc @alanshaw  https://github.com/ipfs/js-ipfs/pull/2377