### PR TITLE
Generate Typescript Typings via JsDoc

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,0 +1,12 @@
+{
+    "recurseDepth": 10,
+    "source": {
+        "include": ["src/"],
+        "exclude": ["node_modules"]
+    },
+    "opts": {
+        "destination": "src/",
+        "template": "./node_modules/tsd-jsdoc/dist",
+        "recurse": true
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
         - npx aegir commitlint --travis
         - npx aegir dep-check -- -i wrtc -i electron-webrtc
         - npm run lint
+        - npm run generate-typings
 
     - stage: test
       name: chrome

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JavaScript implementation of the WebSockets module that libp2p uses and that implements the interface-transport spec",
   "leadMaintainer": "Jacob Heun <jacobheun@gmail.com>",
   "main": "src/index.js",
+  "typings": "src/types.d.ts",
   "scripts": {
     "lint": "aegir lint",
     "build": "aegir build",
@@ -14,7 +15,9 @@
     "release-minor": "aegir release --type minor -t node -t browser",
     "release-major": "aegir release --type major -t node -t browser",
     "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage --provider coveralls"
+    "coverage-publish": "aegir coverage --provider coveralls",
+    "generate-typings": "./node_modules/.bin/jsdoc -c ./.jsdoc.json"
+
   },
   "browser": {
     "src/listener": "./src/listener.browser.js"
@@ -52,9 +55,12 @@
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "interface-transport": "~0.3.7",
+    "jsdoc": "^3.6.3",
     "multiaddr": "^6.0.6",
     "pull-goodbye": "0.0.2",
-    "pull-stream": "^3.6.9"
+    "pull-stream": "^3.6.9",
+    "tsd-jsdoc": "^2.3.1",
+    "typescript-definition-tester": "0.0.6"
   },
   "contributors": [
     "Chris Campbell <christopher.d.campbell@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,16 @@ const log = debug('libp2p:websockets:dialer')
 
 const createListener = require('./listener')
 
+/**
+ * @class
+ */
 class WebSockets {
+  /**
+   * 
+   * @param {*} ma 
+   * @param {object} options 
+   * @param {function} callback 
+   */
   dial (ma, options, callback) {
     if (typeof options === 'function') {
       callback = options
@@ -35,7 +44,11 @@ class WebSockets {
 
     return conn
   }
-
+  /**
+   *
+   * @param {object} options
+   * @param {function} handler
+   */
   createListener (options, handler) {
     if (typeof options === 'function') {
       handler = options
@@ -44,7 +57,10 @@ class WebSockets {
 
     return createListener(options, handler)
   }
-
+  /**
+   *
+   * @param {*} multiaddrs 
+   */
   filter (multiaddrs) {
     if (!Array.isArray(multiaddrs)) {
       multiaddrs = [multiaddrs]

--- a/src/listener.js
+++ b/src/listener.js
@@ -1,5 +1,7 @@
 'use strict'
-
+/**
+ * @module js-libp2p-websockets/listener
+ */
 const Connection = require('interface-connection').Connection
 const multiaddr = require('multiaddr')
 const os = require('os')
@@ -8,7 +10,12 @@ function noop () {}
 
 const createServer = require('pull-ws/server') || noop
 
-module.exports = (options, handler) => {
+/**
+ * Listener
+ * @param {*} options 
+ * @param {*} handler
+ */
+function listener (options, handler) {
   const listener = createServer(options, (socket) => {
     socket.getObservedAddrs = (callback) => {
       // TODO research if we can reuse the address in anyway
@@ -70,3 +77,5 @@ module.exports = (options, handler) => {
 
   return listener
 }
+
+module.exports = listener

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,36 @@
+/**
+ * @class
+ */
+declare class WebSockets {
+    /**
+     *
+     * @param {*} ma
+     * @param {object} options
+     * @param {function} callback
+     */
+    dial(ma: any, options: any, callback: (...params: any[]) => any): void;
+    /**
+     *
+     * @param {object} options
+     * @param {function} handler
+     */
+    createListener(options: any, handler: (...params: any[]) => any): void;
+    /**
+     *
+     * @param {*} multiaddrs
+     */
+    filter(multiaddrs: any): void;
+}
+
+/**
+ * @module js-libp2p-websockets/listener
+ */
+declare module "js-libp2p-websockets/listener" {
+    /**
+     * Listener
+     * @param {*} options
+     * @param {*} handler
+     */
+    function listener(options: any, handler: any): void;
+}
+


### PR DESCRIPTION
Generates Typescript Typings via JsDoc

* Adds typings to the js-libp2p-websocket-star module
* Add typings generation to travis.yml
* Include typings test