### PR TITLE
fix: support multiaddr 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "dirty-chai": "^2.0.1",
     "interface-transport": "~0.3.7",
     "multiaddr": "^6.0.6",
+    "multiaddr7": "npm:multiaddr@^7.0.0",
     "pull-goodbye": "0.0.2",
     "pull-stream": "^3.6.9"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,9 @@ class WebSockets {
         return false
       }
 
-      if (ma.protoNames().includes('ipfs')) {
+      if (typeof ma.decapsulateCode === 'function') {
+        ma = ma.decapsulateCode(421) // multiaddr 7
+      } else if (ma.protoNames().includes('ipfs')) {
         ma = ma.decapsulate('ipfs')
       }
 

--- a/src/listener.js
+++ b/src/listener.js
@@ -25,10 +25,6 @@ module.exports = (options, handler) => {
     callback = callback || noop
     listeningMultiaddr = ma
 
-    if (ma.protoNames().includes('ipfs')) {
-      ma = ma.decapsulate('ipfs')
-    }
-
     listener._listen(ma.toOptions(), callback)
   }
 

--- a/test/node.js
+++ b/test/node.js
@@ -7,6 +7,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const multiaddr = require('multiaddr')
+const multiaddr7 = require('multiaddr7')
 const pull = require('pull-stream')
 const goodbye = require('pull-goodbye')
 
@@ -150,6 +151,21 @@ describe('listen', () => {
         })
       })
     })
+
+    it('getAddrs preserves p2p Id', (done) => {
+      const ma = multiaddr7('/ip4/127.0.0.1/tcp/9090/ws/p2p/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
+
+      const listener = ws.createListener((conn) => { })
+
+      listener.listen(ma, () => {
+        listener.getAddrs((err, addrs) => {
+          expect(err).to.not.exist()
+          expect(addrs.length).to.equal(1)
+          expect(addrs[0]).to.deep.equal(ma)
+          listener.close(done)
+        })
+      })
+    })
   })
 
   describe('ip6', () => {
@@ -191,6 +207,16 @@ describe('listen', () => {
 
     it('listen on addr with /ipfs/QmHASH', (done) => {
       const ma = multiaddr('/ip6/::1/tcp/9091/ws/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
+
+      const listener = ws.createListener((conn) => { })
+
+      listener.listen(ma, () => {
+        listener.close(done)
+      })
+    })
+
+    it('listen on addr with /p2p/QmHASH', (done) => {
+      const ma = multiaddr7('/ip6/::1/tcp/9091/ws/p2p/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
 
       const listener = ws.createListener((conn) => { })
 
@@ -336,6 +362,16 @@ describe('filter addrs', () => {
     it('should filter correct ipv4 addresses with ipfs id', function () {
       const ma1 = multiaddr('/ip4/127.0.0.1/tcp/80/ws/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
       const ma2 = multiaddr('/ip4/127.0.0.1/tcp/80/wss/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
+
+      const valid = ws.filter([ma1, ma2])
+      expect(valid.length).to.equal(2)
+      expect(valid[0]).to.deep.equal(ma1)
+      expect(valid[1]).to.deep.equal(ma2)
+    })
+
+    it('should filter correct ipv4 addresses with p2p id', function () {
+      const ma1 = multiaddr7('/ip4/127.0.0.1/tcp/80/ws/p2p/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
+      const ma2 = multiaddr7('/ip4/127.0.0.1/tcp/80/wss/p2p/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
 
       const valid = ws.filter([ma1, ma2])
       expect(valid.length).to.equal(2)

--- a/test/node.js
+++ b/test/node.js
@@ -97,7 +97,7 @@ describe('listen', () => {
     })
 
     it('getAddrs on port 0 listen', (done) => {
-      const addr = multiaddr(`/ip4/127.0.0.1/tcp/0/ws`)
+      const addr = multiaddr('/ip4/127.0.0.1/tcp/0/ws')
       const listener = ws.createListener((conn) => {
       })
       listener.listen(addr, () => {
@@ -111,7 +111,7 @@ describe('listen', () => {
     })
 
     it('getAddrs from listening on 0.0.0.0', (done) => {
-      const addr = multiaddr(`/ip4/0.0.0.0/tcp/9003/ws`)
+      const addr = multiaddr('/ip4/0.0.0.0/tcp/9003/ws')
       const listener = ws.createListener((conn) => {
       })
       listener.listen(addr, () => {
@@ -124,7 +124,7 @@ describe('listen', () => {
     })
 
     it('getAddrs from listening on 0.0.0.0 and port 0', (done) => {
-      const addr = multiaddr(`/ip4/0.0.0.0/tcp/0/ws`)
+      const addr = multiaddr('/ip4/0.0.0.0/tcp/0/ws')
       const listener = ws.createListener((conn) => {
       })
       listener.listen(addr, () => {


### PR DESCRIPTION
This adds multiaddr 7 support to filtering. multiaddr 7 uses p2p instead of ipfs. Since we currently decapsulate with 'ipfs' this causes valid addresses to get filtered out. Filter will now check for decapsulateCode on the multiaddr and use that if it exists, otherwise it defaults to its previous behavior.