### PR TITLE
test: fix skips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 package-lock.json
 coverage
 .nyc_output
+docs
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ stages:
 
 node_js:
   - '10'
+  - '12'
 
 script: npx nyc -s npm run test:node -- --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 cache: npm
+sudo: false
+
 stages:
   - check
   - test
@@ -9,24 +11,23 @@ node_js:
   - '10'
   - '12'
 
+os:
+  - linux
+  - osx
+  - windows
+
+before_script:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'; fi
+
 script: npx nyc -s npm run test:node -- --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 
 jobs:
   include:
-    - os: linux
-      sudo: false
-      before_script: sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-
-    - os: windows
-      cache: false
-
-    - os: osx
-
     - stage: check
       script:
         - npx aegir build --bundlesize
-        - npx aegir dep-check -- -i wrtc -i electron-webrtc
+        - npx aegir dep-check
         - npm run lint
 
     - stage: test

--- a/test/node.js
+++ b/test/node.js
@@ -75,17 +75,24 @@ describe('listen', () => {
       await listener.close()
     })
 
-    it.skip('close listener with connections, through timeout', (done) => {
-      // TODO `ws` closes all anyway, we need to make it not close
-      // first - https://github.com/diasdavid/simple-websocket-server
+    it('listen on port 0', async () => {
+      const ma = multiaddr('/ip4/127.0.0.1/tcp/0/ws/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
+      const listener = ws.createListener((conn) => { })
+
+      await listener.listen(ma)
+      const addrs = await listener.getAddrs()
+      expect(addrs.map((a) => a.toOptions().port)).to.not.include(0)
+      await listener.close()
     })
 
-    it.skip('listen on port 0', (done) => {
-      // TODO port 0 not supported yet
-    })
+    it('listen on any Interface', async () => {
+      const ma = multiaddr('/ip4/0.0.0.0/tcp/0/ws/ipfs/Qmb6owHp6eaWArVbcJJbQSyifyJBttMMjYV76N2hMbf5Vw')
+      const listener = ws.createListener((conn) => { })
 
-    it.skip('listen on any Interface', (done) => {
-      // TODO 0.0.0.0 not supported yet
+      await listener.listen(ma)
+      const addrs = await listener.getAddrs()
+      expect(addrs.map((a) => a.toOptions().host)).to.not.include('0.0.0.0')
+      await listener.close()
     })
 
     it('getAddrs', async () => {


### PR DESCRIPTION
The ephemeral port and host skips are no longer valid, so tests have been added for those.
The other skipped test is now covered by the interface tests, so it's no longer needed.
