### PR TITLE
fix: support bufferlist usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "abort-controller": "^3.0.0",
     "aegir": "^20.3.1",
+    "bl": "^4.0.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "interface-transport": "^0.7.0",

--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -20,7 +20,12 @@ module.exports = (socket, options = {}) => {
       }
 
       try {
-        await socket.sink(source)
+        await socket.sink((async function * () {
+          for await (const chunk of source) {
+            // Convert BufferList to Buffer
+            yield Buffer.isBuffer(chunk) ? chunk : chunk.slice()
+          }
+        })())
       } catch (err) {
         if (err.type !== 'aborted') {
           log.error(err)

--- a/test/node.js
+++ b/test/node.js
@@ -13,6 +13,7 @@ const multiaddr = require('multiaddr')
 const goodbye = require('it-goodbye')
 const { collect } = require('streaming-iterables')
 const pipe = require('it-pipe')
+const BufferList = require('bl/BufferList')
 
 const WS = require('../src')
 
@@ -295,6 +296,15 @@ describe('dial', () => {
     it('dial', async () => {
       const conn = await ws.dial(ma)
       const s = goodbye({ source: ['hey'], sink: collect })
+
+      const result = await pipe(s, conn, s)
+
+      expect(result).to.be.eql([Buffer.from('hey')])
+    })
+
+    it('dial and use BufferList', async () => {
+      const conn = await ws.dial(ma)
+      const s = goodbye({ source: [new BufferList('hey')], sink: collect })
 
       const result = await pipe(s, conn, s)
 


### PR DESCRIPTION
several it-* modules leverage bufferlist, but ws does not. We need to convert buffer lists to buffers before handing the data off to ws for transmission

libp2p-tcp does this, https://github.com/libp2p/js-libp2p-tcp/blob/master/src/socket-to-conn.js#L22-L27