### PR TITLE
fix: catch thrown maConn errors in listener

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -14,16 +14,15 @@ module.exports = ({ handler, upgrader }, options = {}) => {
   const listener = new EventEmitter()
 
   const server = createServer(options, async (stream) => {
-    const maConn = toConnection(stream)
+    let maConn, conn
 
-    log('new inbound connection %s', maConn.remoteAddr)
-
-    let conn
     try {
+      maConn = toConnection(stream)
+      log('new inbound connection %s', maConn.remoteAddr)
       conn = await upgrader.upgradeInbound(maConn)
     } catch (err) {
       log.error('inbound connection failed to upgrade', err)
-      return maConn.close()
+      return maConn && maConn.close()
     }
 
     log('inbound connection %s upgraded', maConn.remoteAddr)


### PR DESCRIPTION
When upgrading sockets to MultiaddConnections, it's possible for an error to be thrown.
This can crash the application if a client disconnects prior to the listener
uprading the socket. Errors will now be caught and logged
when attempting to upgrade the socket.

Per comment on [libp2p/js-libp2p-websockets#106#pullrequestreview-364926334](https://github.com/libp2p/js-libp2p-websockets/pull/106#pullrequestreview-364926334)