### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "libp2p-utils": "^0.2.0",
     "mafmt": "^8.0.0",
     "multiaddr": "^8.0.0",
-    "multiaddr-to-uri": "multiformats/js-multiaddr-to-uri#chore/update-deps",
+    "multiaddr-to-uri": "^6.0.0",
     "p-timeout": "^3.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,27 +39,25 @@
   "homepage": "https://github.com/libp2p/js-libp2p-websockets#readme",
   "dependencies": {
     "abortable-iterator": "^3.0.0",
-    "buffer": "^5.5.0",
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
     "it-ws": "^3.0.0",
-    "libp2p-utils": "~0.1.0",
-    "mafmt": "^7.0.0",
-    "multiaddr": "^7.1.0",
-    "multiaddr-to-uri": "^5.0.0",
+    "libp2p-utils": "^0.2.0",
+    "mafmt": "^8.0.0",
+    "multiaddr": "^8.0.0",
+    "multiaddr-to-uri": "multiformats/js-multiaddr-to-uri#chore/update-deps",
     "p-timeout": "^3.2.0"
   },
   "devDependencies": {
     "abort-controller": "^3.0.0",
-    "aegir": "^21.4.4",
+    "aegir": "^25.0.0",
     "bl": "^4.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
     "it-goodbye": "^2.0.1",
     "it-pipe": "^1.0.1",
-    "libp2p-interfaces": "^0.2.0",
-    "streaming-iterables": "^4.1.0"
+    "libp2p-interfaces": "^0.4.0",
+    "streaming-iterables": "^5.0.2",
+    "uint8arrays": "^1.1.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const abortable = require('abortable-iterator')
 const { CLOSE_TIMEOUT } = require('./constants')
 const toMultiaddr = require('libp2p-utils/src/ip-port-to-multiaddr')
@@ -24,7 +23,7 @@ module.exports = (stream, options = {}) => {
         await stream.sink((async function * () {
           for await (const chunk of source) {
             // Convert BufferList to Buffer
-            yield Buffer.isBuffer(chunk) ? chunk : chunk.slice()
+            yield chunk instanceof Uint8Array ? chunk : chunk.slice()
           }
         })())
       } catch (err) {

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,15 +1,13 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 
 const multiaddr = require('multiaddr')
 const pipe = require('it-pipe')
 const goodbye = require('it-goodbye')
 const { collect, take } = require('streaming-iterables')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const WS = require('../src')
 
@@ -29,7 +27,7 @@ describe('libp2p-websockets', () => {
   })
 
   it('echo', async () => {
-    const message = Buffer.from('Hello World!')
+    const message = uint8ArrayFromString('Hello World!')
     const s = goodbye({ source: [message], sink: collect })
 
     const results = await pipe(s, conn, s)
@@ -38,7 +36,7 @@ describe('libp2p-websockets', () => {
 
   describe('stress', () => {
     it('one big write', async () => {
-      const rawMessage = Buffer.allocUnsafe(1000000).fill('a')
+      const rawMessage = new Uint8Array(1000000).fill('a')
 
       const s = goodbye({ source: [rawMessage], sink: collect })
 
@@ -52,7 +50,7 @@ describe('libp2p-websockets', () => {
         source: pipe(
           {
             [Symbol.iterator] () { return this },
-            next: () => ({ done: false, value: Buffer.from(Math.random().toString()) })
+            next: () => ({ done: false, value: uint8ArrayFromString(Math.random().toString()) })
           },
           take(20000)
         ),

--- a/test/node.js
+++ b/test/node.js
@@ -5,15 +5,13 @@
 const https = require('https')
 const fs = require('fs')
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multiaddr = require('multiaddr')
 const goodbye = require('it-goodbye')
 const { collect } = require('streaming-iterables')
 const pipe = require('it-pipe')
 const BufferList = require('bl/BufferList')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const WS = require('../src')
 
@@ -211,7 +209,7 @@ describe('dial', () => {
 
       const result = await pipe(s, conn, s)
 
-      expect(result).to.be.eql([Buffer.from('hey')])
+      expect(result).to.be.eql([uint8ArrayFromString('hey')])
     })
 
     it('dial with p2p Id', async () => {
@@ -221,7 +219,7 @@ describe('dial', () => {
 
       const result = await pipe(s, conn, s)
 
-      expect(result).to.be.eql([Buffer.from('hey')])
+      expect(result).to.be.eql([uint8ArrayFromString('hey')])
     })
 
     it('should resolve port 0', async () => {
@@ -276,7 +274,7 @@ describe('dial', () => {
 
       const result = await pipe(s, conn, s)
 
-      expect(result).to.be.eql([Buffer.from('hey')])
+      expect(result).to.be.eql([uint8ArrayFromString('hey')])
     })
   })
 
@@ -299,7 +297,7 @@ describe('dial', () => {
 
       const result = await pipe(s, conn, s)
 
-      expect(result).to.be.eql([Buffer.from('hey')])
+      expect(result).to.be.eql([uint8ArrayFromString('hey')])
     })
 
     it('dial and use BufferList', async () => {
@@ -308,7 +306,7 @@ describe('dial', () => {
 
       const result = await pipe(s, conn, s)
 
-      expect(result).to.be.eql([Buffer.from('hey')])
+      expect(result).to.be.eql([uint8ArrayFromString('hey')])
     })
 
     it('dial with p2p Id', async () => {
@@ -321,7 +319,7 @@ describe('dial', () => {
       })
 
       const result = await pipe(s, conn, s)
-      expect(result).to.be.eql([Buffer.from('hey')])
+      expect(result).to.be.eql([uint8ArrayFromString('hey')])
     })
   })
 })


### PR DESCRIPTION
Depends on:

- [x] https://github.com/multiformats/js-multiaddr-to-uri/pull/45

BREAKING CHANGES:

- All deps used by this module now use Uint8Arrays in place of Buffers