### PR TITLE
feat: adds transportTag to maConn

### DIFF
--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -45,6 +45,8 @@ module.exports = (stream, options = {}) => {
 
     timeline: { open: Date.now() },
 
+    transportTag: 'WebSockets',
+
     async close () {
       const start = Date.now()
 


### PR DESCRIPTION
Adds `transportTag` parameter to `maConn` passed to upgrader to create Connection.

To adhere to https://github.com/libp2p/js-libp2p/pull/854 to solve https://github.com/libp2p/js-libp2p/issues/838