### PR TITLE
fix: listener get addrs with wss

### DIFF
--- a/test/node.js
+++ b/test/node.js
@@ -311,6 +311,13 @@ describe('dial', () => {
 
     afterEach(() => listener.close())
 
+    it('should listen on wss address', () => {
+      const addrs = listener.getAddrs()
+
+      expect(addrs).to.have.lengthOf(1)
+      expect(ma.equals(addrs[0])).to.eql(true)
+    })
+
     it('dial', async () => {
       const conn = await ws.dial(ma, { websocket: { rejectUnauthorized: false } })
       const s = goodbye({ source: ['hey'], sink: collect })


### PR DESCRIPTION
Related to the flagged issue in https://github.com/libp2p/js-libp2p/pull/930

Shortly, when libp2p calls `libp2p.transportManager.getAddrs()`, the underlying websockets transport would return a `ws` multiaddr when listening on a `wss` multiaddr and this address was being incorrectly advertised  