### PR TITLE
fix: pass abort signal to upgrader

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,15 +53,15 @@
   },
   "devDependencies": {
     "abort-controller": "^3.0.0",
-    "aegir": "^33.0.0",
+    "aegir": "^36.1.1",
     "bl": "^5.0.0",
     "is-loopback-addr": "^1.0.1",
     "it-goodbye": "^3.0.0",
     "it-pipe": "^1.1.0",
-    "libp2p-interfaces": "^1.0.0",
-    "libp2p-interfaces-compliance-tests": "^1.0.0",
+    "libp2p-interfaces": "^2.0.3",
+    "libp2p-interfaces-compliance-tests": "^2.0.4",
     "streaming-iterables": "^6.0.0",
-    "uint8arrays": "^2.1.2",
+    "uint8arrays": "^3.0.0",
     "util": "^0.12.3"
   },
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const filters = require('./filters')
 
 /**
  * @typedef {import('multiaddr').Multiaddr} Multiaddr
+ * @typedef {import('libp2p-interfaces/src/types').AbortOptions} AbortOptions
  */
 
 /**
@@ -40,8 +41,7 @@ class WebSockets {
   /**
    * @async
    * @param {Multiaddr} ma
-   * @param {object} [options]
-   * @param {AbortSignal} [options.signal] - Used to abort dial requests
+   * @param {AbortOptions} [options]
    * @returns {Connection} An upgraded Connection
    */
   async dial (ma, options = {}) {
@@ -51,7 +51,7 @@ class WebSockets {
     const maConn = toConnection(socket, { remoteAddr: ma, signal: options.signal })
     log('new outbound connection %s', maConn.remoteAddr)
 
-    const conn = await this._upgrader.upgradeOutbound(maConn)
+    const conn = await this._upgrader.upgradeOutbound(maConn, options)
     log('outbound connection %s upgraded', maConn.remoteAddr)
     return conn
   }

--- a/src/listener.js
+++ b/src/listener.js
@@ -8,6 +8,10 @@ const debug = require('debug')
 const log = debug('libp2p:websockets:listener')
 log.error = debug('libp2p:websockets:listener:error')
 
+/**
+ * @typedef {import('libp2p-interfaces/src/types').AbortOptions} AbortOptions
+ */
+
 const toConnection = require('./socket-to-conn')
 
 module.exports = ({ handler, upgrader }, options = {}) => {
@@ -19,7 +23,7 @@ module.exports = ({ handler, upgrader }, options = {}) => {
     try {
       maConn = toConnection(stream)
       log('new inbound connection %s', maConn.remoteAddr)
-      conn = await upgrader.upgradeInbound(maConn)
+      conn = await upgrader.upgradeInbound(maConn, options)
     } catch (err) {
       log.error('inbound connection failed to upgrade', err)
       return maConn && maConn.close()

--- a/test/browser.js
+++ b/test/browser.js
@@ -7,7 +7,7 @@ const { Multiaddr } = require('multiaddr')
 const pipe = require('it-pipe')
 const goodbye = require('it-goodbye')
 const { collect, take } = require('streaming-iterables')
-const uint8ArrayFromString = require('uint8arrays/from-string')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 const WS = require('../src')
 

--- a/test/node.js
+++ b/test/node.js
@@ -13,7 +13,7 @@ const isLoopbackAddr = require('is-loopback-addr')
 const { collect } = require('streaming-iterables')
 const pipe = require('it-pipe')
 const BufferList = require('bl/BufferList')
-const uint8ArrayFromString = require('uint8arrays/from-string')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 const WS = require('../src')
 const filters = require('../src/filters')


### PR DESCRIPTION
In order to abort in-progress dials and not leak memory, the abort signal must be passed to the upgrader in order for it to be passed on to mss and noise.

Refs: https://github.com/libp2p/js-libp2p/pull/1072