### PR TITLE
fix: remove connection from tracking list on close

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -29,6 +29,10 @@ module.exports = ({ handler, upgrader }, options = {}) => {
 
     trackConn(server, maConn)
 
+    stream.on('close', () => {
+      server.__connections = server.__connections.filter(conn => conn !== maConn)
+    })
+
     if (handler) handler(conn)
     listener.emit('connection', conn)
   })


### PR DESCRIPTION
If a socket closes we should remove the connection from the list of connections we are tracking, otherwise we have a memory leak.

Fixes #139