### PR TITLE
fix: remove entrypoint config

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -39,6 +39,6 @@ export default {
     }
   },
   build: {
-    bundlesizeMax: '66kB'
+    bundlesizeMax: '18kB'
   }
 }

--- a/.aegir.js
+++ b/.aegir.js
@@ -39,8 +39,6 @@ export default {
     }
   },
   build: {
-    config: {
-      entryPoints: ['./dist/src/index.js']
-    }
+    bundlesizeMax: '66kB'
   }
 }

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "@libp2p/interface-compliance-tests": "^1.1.21",
     "@libp2p/interfaces": "^1.3.20",
     "@types/ws": "^8.2.2",
-    "aegir": "^37.0.11",
+    "aegir": "^37.0.12",
     "is-loopback-addr": "^2.0.1",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",
@@ -179,6 +179,6 @@
     "uint8arrays": "^3.0.0"
   },
   "browser": {
-    "./src/listener.js": "./src/listener.browser.js"
+    "./dist/src/listener.js": "./dist/src/listener.browser.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "@libp2p/interface-compliance-tests": "^1.1.21",
     "@libp2p/interfaces": "^1.3.20",
     "@types/ws": "^8.2.2",
-    "aegir": "^37.0.7",
+    "aegir": "^37.0.11",
     "is-loopback-addr": "^2.0.1",
     "it-all": "^1.0.6",
     "it-drain": "^1.0.5",
@@ -179,6 +179,6 @@
     "uint8arrays": "^3.0.0"
   },
   "browser": {
-    "./dist/src/listener.js": "./dist/src/listener.browser.js"
+    "./src/listener.js": "./src/listener.browser.js"
   }
 }


### PR DESCRIPTION
The extra config wasn't necessary, upgrades aegir to run the tests in a way that respects the browser override field in package.json.