### PR TITLE
fix: update dial function return type to avoid Connection import issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { createListener } from './listener.js'
 import { socketToMaConn } from './socket-to-conn.js'
 import * as filters from './filters.js'
 import { Transport, MultiaddrFilter, symbol, CreateListenerOptions, DialOptions } from '@libp2p/interface-transport'
+import type { Connection } from '@libp2p/interface-connection'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { DuplexWebSocket } from 'it-ws/duplex'
@@ -37,7 +38,7 @@ export class WebSockets implements Transport {
     return true
   }
 
-  async dial (ma: Multiaddr, options: DialOptions) {
+  async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
     log('dialing %s', ma)
     options = options ?? {}
 


### PR DESCRIPTION
- I've noticed an issue when including this package in another typescript project. The `index.d.ts` file created during the build process would include an in-line import in the `dial` function declaration of `Promise<import("@libp2p/interface-connection/dist/src").Connection>;`
- This would result in the following build error in my project:
`../../node_modules/@libp2p/websockets/dist/src/index.d.ts(19,104): error TS2694: Namespace '"@libp2p/interface-connection/dist/src"' has no exported member 'Connection'.`
- By declaring the `Connection` import explicitly, we avoid the strange in-line import of a `dist/src` location and I am able to build my project correctly.

I believe it is possible that this issue: https://github.com/libp2p/js-libp2p-websockets/issues/163 is also the result of the behavior I was seeing, and this PR may resolve that issue.