### PR TITLE
fix: socket close event not working in browser

### DIFF
--- a/src/socket-to-conn.ts
+++ b/src/socket-to-conn.ts
@@ -58,14 +58,14 @@ export function socketToMaConn (stream: DuplexWebSocket, remoteAddr: Multiaddr, 
     }
   }
 
-  stream.socket.once != null && stream.socket.once('close', () => { // eslint-disable-line @typescript-eslint/prefer-optional-chain
+  stream.socket.addEventListener('close', () => {
     // In instances where `close` was not explicitly called,
     // such as an iterable stream ending, ensure we have set the close
     // timeline
     if (maConn.timeline.close == null) {
       maConn.timeline.close = Date.now()
     }
-  })
+  }, { once: true })
 
   return maConn
 }


### PR DESCRIPTION
I simulated that it's not working by attaching a socket to a conn object that I can manually close. Not sure how to trigger the close socket event without hacking (or without calling close on conn)

resolves #179 