### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -6,7 +6,7 @@ import { pipe }from 'it-pipe'
 export default {
   test: {
     async before () {
-      const { WebSockets } = await import('./dist/src/index.js')
+      const { webSockets } = await import('./dist/src/index.js')
 
       const protocol = '/echo/1.0.0'
       const registrar = mockRegistrar()
@@ -20,7 +20,7 @@ export default {
         registrar
       })
 
-      const ws = new WebSockets()
+      const ws = webSockets()()
       const ma = multiaddr('/ip4/127.0.0.1/tcp/9095/ws')
       const listener = ws.createListener({
         upgrader

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # @libp2p/websockets <!-- omit in toc -->
 
 [![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
-[![IRC](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
 [![codecov](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-websockets.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-websockets)
-[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-interfaces/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/libp2p/js-libp2p-websockets/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-websockets/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/libp2p/js-libp2p-websockets/actions/workflows/js-test-and-release.yml)
 
 > JavaScript implementation of the WebSockets module that libp2p uses and that implements the interface-transport spec
 
 ## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
-- [Description](#description)
 - [Usage](#usage)
   - [Constructor properties](#constructor-properties)
 - [Libp2p Usage Example](#libp2p-usage-example)
@@ -30,10 +28,6 @@ $ npm i @libp2p/websockets
 [![](https://raw.githubusercontent.com/libp2p/interface-transport/master/img/badge.png)](https://github.com/libp2p/interface-transport)
 [![](https://raw.githubusercontent.com/libp2p/interface-connection/master/img/badge.png)](https://github.com/libp2p/interface-connection)
 
-## Description
-
-`libp2p-websockets` is the WebSockets implementation compatible with libp2p.
-
 ## Usage
 
 ```sh
@@ -43,14 +37,17 @@ $ npm i @libp2p/websockets
 ### Constructor properties
 
 ```js
-import { WebSockets } from '@libp2p/websockets'
+import { createLibp2pNode } from 'libp2p'
+import { webSockets } from '@libp2p/webrtc-direct'
 
-const properties = {
-  upgrader,
-  filter
-}
-
-const ws = new WebSockets(properties)
+const node = await createLibp2p({
+  transports: [
+    webSockets()
+  ]
+  //... other config
+})
+await node.start()
+await node.dial('/ip4/127.0.0.1/tcp/9090/ws')
 ```
 
 | Name     | Type                                                                                                                       | Description                                                            | Default                                                                 |
@@ -72,26 +69,26 @@ The available filters are:
 ## Libp2p Usage Example
 
 ```js
-import Libp2p from 'libp2p'
-import { Websockets } from '@libp2p/websockets'
-import filters from 'libp2p-websockets/filters'
-import { MPLEX } from 'libp2p-mplex'
-import { NOISE } from 'libp2p-noise'
+import { createLibp2pNode } from 'libp2p'
+import { websockets } from '@libp2p/websockets'
+import filters from '@libp2p/websockets/filters'
+import { mplex } from '@libp2p/mplex'
+import { noise } from '@libp2p/noise'
 
 const transportKey = Websockets.prototype[Symbol.toStringTag]
 const node = await Libp2p.create({
-  modules: {
-    transport: [Websockets],
-    streamMuxer: [MPLEX],
-    connEncryption: [NOISE]
-  },
-  config: {
-    transport: {
-      [transportKey]: { // Transport properties -- Libp2p upgrader is automatically added
-        filter: filters.dnsWsOrWss
-      }
-    }
-  }
+  transport: [
+    websockets({
+      // connect to all sockets, even insecure ones
+      filters: filters.all
+    })
+  ],
+  streamMuxers: [
+    mplex()
+  ],
+  connectionEncryption: [
+    noise()
+  ]
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -174,8 +174,8 @@
     "wherearewe": "^2.0.1"
   },
   "devDependencies": {
-    "@libp2p/interface-mocks": "^6.0.1",
-    "@libp2p/interface-transport-compliance-tests": "^2.0.6",
+    "@libp2p/interface-mocks": "^7.0.1",
+    "@libp2p/interface-transport-compliance-tests": "^3.0.0",
     "@types/ws": "^8.2.2",
     "aegir": "^37.5.3",
     "is-loopback-addr": "^2.0.1",
@@ -187,7 +187,7 @@
     "it-take": "^1.0.2",
     "p-wait-for": "^5.0.0",
     "uint8arraylist": "^2.3.2",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^4.0.2"
   },
   "browser": {
     "./dist/src/listener.js": "./dist/src/listener.browser.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export interface WebSocketsInit extends AbortOptions, WebSocketOptions {
   server?: Server
 }
 
-export class WebSockets implements Transport {
+class WebSockets implements Transport {
   private readonly init?: WebSocketsInit
 
   constructor (init?: WebSocketsInit) {
@@ -137,5 +137,11 @@ export class WebSockets implements Transport {
     }
 
     return filters.all(multiaddrs)
+  }
+}
+
+export function webSockets (init: WebSocketsInit = {}): (components?: any) => Transport {
+  return () => {
+    return new WebSockets(init)
   }
 }

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -5,20 +5,21 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { pipe } from 'it-pipe'
 import all from 'it-all'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { WebSockets } from '../src/index.js'
+import { webSockets } from '../src/index.js'
 import { mockUpgrader } from '@libp2p/interface-mocks'
 import { isBrowser, isWebWorker } from 'wherearewe'
 import type { Connection } from '@libp2p/interface-connection'
+import type { Transport } from '@libp2p/interface-transport'
 
 const protocol = '/echo/1.0.0'
 
 describe('libp2p-websockets', () => {
   const ma = multiaddr('/ip4/127.0.0.1/tcp/9095/ws')
-  let ws: WebSockets
+  let ws: Transport
   let conn: Connection
 
   beforeEach(async () => {
-    ws = new WebSockets()
+    ws = webSockets()()
     conn = await ws.dial(ma, { upgrader: mockUpgrader() })
   })
 
@@ -86,6 +87,6 @@ describe('libp2p-websockets', () => {
   })
 
   it('.createServer throws in browser', () => {
-    expect(new WebSockets().createListener).to.throw()
+    expect(webSockets()().createListener).to.throw()
   })
 })

--- a/test/compliance.node.ts
+++ b/test/compliance.node.ts
@@ -3,14 +3,14 @@
 import tests from '@libp2p/interface-transport-compliance-tests'
 import { multiaddr } from '@multiformats/multiaddr'
 import http from 'http'
-import { WebSockets } from '../src/index.js'
+import { webSockets } from '../src/index.js'
 import * as filters from '../src/filters.js'
 import type { WebSocketListenerInit } from '../src/listener.js'
 
 describe('interface-transport compliance', () => {
   tests({
     async setup () {
-      const ws = new WebSockets({ filter: filters.all })
+      const ws = webSockets({ filter: filters.all })()
       const addrs = [
         multiaddr('/ip4/127.0.0.1/tcp/9091/ws'),
         multiaddr('/ip4/127.0.0.1/tcp/9092/ws'),

--- a/test/node.ts
+++ b/test/node.ts
@@ -346,7 +346,7 @@ describe('dial', () => {
         cert: fs.readFileSync('./test/fixtures/certificate.pem'),
         key: fs.readFileSync('./test/fixtures/key.pem')
       })
-      ws = webSockets()({ websocket: { rejectUnauthorized: false }, server })
+      ws = webSockets({ websocket: { rejectUnauthorized: false }, server })()
       listener = ws.createListener({
         handler: (conn) => {
           void conn.newStream([protocol]).then(async (stream) => {

--- a/test/node.ts
+++ b/test/node.ts
@@ -13,10 +13,10 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
 import defer from 'p-defer'
 import waitFor from 'p-wait-for'
-import { WebSockets } from '../src/index.js'
+import { webSockets } from '../src/index.js'
 import * as filters from '../src/filters.js'
 import drain from 'it-drain'
-import type { Listener } from '@libp2p/interface-transport'
+import type { Listener, Transport } from '@libp2p/interface-transport'
 import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Source } from 'it-stream-types'
 import './compliance.node.js'
@@ -43,7 +43,7 @@ const upgrader = mockUpgrader({
 
 describe('instantiate the transport', () => {
   it('create', () => {
-    const ws = new WebSockets()
+    const ws = webSockets()()
     expect(ws).to.exist()
   })
 })
@@ -52,7 +52,7 @@ describe('listen', () => {
   it('should close connections when stopping the listener', async () => {
     const ma = multiaddr('/ip4/127.0.0.1/tcp/47382/ws')
 
-    const ws = new WebSockets()
+    const ws = webSockets()()
     const listener = ws.createListener({
       handler: (conn) => {
         void conn.newStream([protocol]).then(async (stream) => {
@@ -75,12 +75,12 @@ describe('listen', () => {
   })
 
   describe('ip4', () => {
-    let ws: WebSockets
+    let ws: Transport
     const ma = multiaddr('/ip4/127.0.0.1/tcp/47382/ws')
     let listener: Listener
 
     beforeEach(() => {
-      ws = new WebSockets()
+      ws = webSockets()()
     })
 
     afterEach(async () => {
@@ -184,11 +184,11 @@ describe('listen', () => {
   })
 
   describe('ip6', () => {
-    let ws: WebSockets
+    let ws: Transport
     const ma = multiaddr('/ip6/::1/tcp/9091/ws')
 
     beforeEach(() => {
-      ws = new WebSockets()
+      ws = webSockets()()
     })
 
     it('listen, check for promise', async () => {
@@ -229,12 +229,12 @@ describe('listen', () => {
 
 describe('dial', () => {
   describe('ip4', () => {
-    let ws: WebSockets
+    let ws: Transport
     let listener: Listener
     const ma = multiaddr('/ip4/127.0.0.1/tcp/9091/ws')
 
     beforeEach(async () => {
-      ws = new WebSockets()
+      ws = webSockets()()
       listener = ws.createListener({ upgrader })
       return await listener.listen(ma)
     })
@@ -270,7 +270,7 @@ describe('dial', () => {
 
     it('should resolve port 0', async () => {
       const ma = multiaddr('/ip4/127.0.0.1/tcp/0/ws')
-      const ws = new WebSockets()
+      const ws = webSockets()()
 
       // Create a Promise that resolves when a connection is handled
       const deferred = defer()
@@ -295,12 +295,12 @@ describe('dial', () => {
   })
 
   describe('ip4 no loopback', () => {
-    let ws: WebSockets
+    let ws: Transport
     let listener: Listener
     const ma = multiaddr('/ip4/0.0.0.0/tcp/0/ws')
 
     beforeEach(async () => {
-      ws = new WebSockets()
+      ws = webSockets()()
       listener = ws.createListener({
         handler: (conn) => {
           void conn.newStream([protocol]).then(async (stream) => {
@@ -336,7 +336,7 @@ describe('dial', () => {
   })
 
   describe('ip4 with wss', () => {
-    let ws: WebSockets
+    let ws: Transport
     let listener: Listener
     const ma = multiaddr('/ip4/127.0.0.1/tcp/37284/wss')
     let server: https.Server
@@ -346,7 +346,7 @@ describe('dial', () => {
         cert: fs.readFileSync('./test/fixtures/certificate.pem'),
         key: fs.readFileSync('./test/fixtures/key.pem')
       })
-      ws = new WebSockets({ websocket: { rejectUnauthorized: false }, server })
+      ws = webSockets()({ websocket: { rejectUnauthorized: false }, server })
       listener = ws.createListener({
         handler: (conn) => {
           void conn.newStream([protocol]).then(async (stream) => {
@@ -383,12 +383,12 @@ describe('dial', () => {
   })
 
   describe('ip6', () => {
-    let ws: WebSockets
+    let ws: Transport
     let listener: Listener
     const ma = multiaddr('/ip6/::1/tcp/9091/ws')
 
     beforeEach(async () => {
-      ws = new WebSockets()
+      ws = webSockets()()
       listener = ws.createListener({
         handler: (conn) => {
           void conn.newStream([protocol]).then(async (stream) => {
@@ -426,11 +426,11 @@ describe('dial', () => {
 })
 
 describe('filter addrs', () => {
-  let ws: WebSockets
+  let ws: Transport
 
   describe('default filter addrs with only dns', () => {
     before(() => {
-      ws = new WebSockets()
+      ws = webSockets()()
     })
 
     it('should filter out invalid WS addresses', function () {
@@ -498,7 +498,7 @@ describe('filter addrs', () => {
 
   describe('custom filter addrs', () => {
     before(() => {
-      ws = new WebSockets({ filter: filters.all })
+      ws = webSockets()({ filter: filters.all })
     })
 
     it('should fail invalid WS addresses', function () {


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection