### PR TITLE
Export the WebSockets class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export interface WebSocketsInit extends AbortOptions, WebSocketOptions {
   server?: Server
 }
 
-class WebSockets implements Transport {
+export class WebSockets implements Transport {
   private readonly init?: WebSocketsInit
 
   constructor (init?: WebSocketsInit) {


### PR DESCRIPTION
I'm looking to extend the WebSockets transport and it's impossible to do this without pulling the module in as a submodule because the class isn't exported.