### PR TITLE
fix: Only filter by wss not dns

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -21,7 +21,7 @@ export function all (multiaddrs: Multiaddr[]) {
   })
 }
 
-export function dnsWss (multiaddrs: Multiaddr[]) {
+export function wss (multiaddrs: Multiaddr[]) {
   return multiaddrs.filter((ma) => {
     if (ma.protoCodes().includes(CODE_CIRCUIT)) {
       return false
@@ -29,8 +29,7 @@ export function dnsWss (multiaddrs: Multiaddr[]) {
 
     const testMa = ma.decapsulateCode(CODE_P2P)
 
-    return mafmt.WebSocketsSecure.matches(testMa) &&
-      mafmt.DNS.matches(testMa.decapsulateCode(CODE_TCP).decapsulateCode(CODE_WSS))
+    return mafmt.WebSocketsSecure.matches(testMa)
   })
 }
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -33,6 +33,19 @@ export function wss (multiaddrs: Multiaddr[]) {
   })
 }
 
+export function dnsWss (multiaddrs: Multiaddr[]) {
+  return multiaddrs.filter((ma) => {
+    if (ma.protoCodes().includes(CODE_CIRCUIT)) {
+      return false
+    }
+
+    const testMa = ma.decapsulateCode(CODE_P2P)
+
+    return mafmt.WebSocketsSecure.matches(testMa) &&
+      mafmt.DNS.matches(testMa.decapsulateCode(CODE_TCP).decapsulateCode(CODE_WSS))
+  })
+}
+
 export function dnsWsOrWss (multiaddrs: Multiaddr[]) {
   return multiaddrs.filter((ma) => {
     if (ma.protoCodes().includes(CODE_CIRCUIT)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ class WebSockets implements Transport {
 
     // Browser
     if (isBrowser || isWebWorker) {
-      return filters.dnsWss(multiaddrs)
+      return filters.wss(multiaddrs)
     }
 
     return filters.all(multiaddrs)

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -40,7 +40,7 @@ describe('libp2p-websockets', () => {
     expect(res[0].subarray()).to.equalBytes(data)
   })
 
-  it('should filter out no DNS websocket addresses', function () {
+  it('should filter out no wss websocket addresses', function () {
     const ma1 = multiaddr('/ip4/127.0.0.1/tcp/80/ws')
     const ma2 = multiaddr('/ip4/127.0.0.1/tcp/443/wss')
     const ma3 = multiaddr('/ip6/::1/tcp/80/ws')
@@ -49,7 +49,8 @@ describe('libp2p-websockets', () => {
     const valid = ws.filter([ma1, ma2, ma3, ma4])
 
     if (isBrowser || isWebWorker) {
-      expect(valid.length).to.equal(0)
+      expect(valid.length).to.equal(2)
+      expect(valid).to.equal([ma2, ma4])
     } else {
       expect(valid.length).to.equal(4)
     }

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -50,7 +50,7 @@ describe('libp2p-websockets', () => {
 
     if (isBrowser || isWebWorker) {
       expect(valid.length).to.equal(2)
-      expect(valid).to.equal([ma2, ma4])
+      expect(valid).to.deep.equal([ma2, ma4])
     } else {
       expect(valid.length).to.equal(4)
     }


### PR DESCRIPTION
Browsers can dial IP addresses just fine. There's no need for this to be only DNS addresses. 