### PR TITLE
deps: add ws types to main dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "@multiformats/mafmt": "^12.0.0",
     "@multiformats/multiaddr": "^12.0.0",
     "@multiformats/multiaddr-to-uri": "^9.0.2",
+    "@types/ws": "^8.5.4",
     "abortable-iterator": "^5.0.0",
     "it-ws": "^6.0.0",
     "p-defer": "^4.0.0",
@@ -177,7 +178,6 @@
   "devDependencies": {
     "@libp2p/interface-mocks": "^11.0.0",
     "@libp2p/interface-transport-compliance-tests": "^4.0.0",
-    "@types/ws": "^8.2.2",
     "aegir": "^38.1.7",
     "is-loopback-addr": "^2.0.1",
     "it-all": "^3.0.1",


### PR DESCRIPTION
While following the example of how to do a basic libp2p setup, if we only configure webSockets as our [transport](https://github.com/libp2p/js-libp2p/blob/master/doc/GETTING_STARTED.md#transports) the types will be undefined.

```bash
node_modules/@libp2p/websockets/dist/src/index.d.ts:5:36 - error TS7016: Could not find a declaration file for module 'ws'. '/Users/horizon/Desktop/test/node_modules/ws/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`

5 import type { ClientOptions } from 'ws';
                                     ~~~~
```

Perhaps these types should be exported in a better way? Especially since they are required in [it-ws](https://www.npmjs.com/package/it-ws) but if so then maybe the are not properly [exported there](https://github.com/alanshaw/it-ws/blob/master/package.json#L50)

```bash
node_modules/it-ws/dist/src/client.d.ts:1:36 - error TS7016: Could not find a declaration file for module 'ws'. '/Users/horizon/Desktop/test/node_modules/ws/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`

1 import type { ClientOptions } from 'ws';
                                     ~~~~

node_modules/it-ws/dist/src/duplex.d.ts:1:23 - error TS2688: Cannot find type definition file for 'ws'.

1 /// <reference types="ws" />
                        ~~

node_modules/it-ws/dist/src/sink.d.ts:1:32 - error TS7016: Could not find a declaration file for module 'ws'. '/Users/horizon/Desktop/test/node_modules/ws/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`

1 import type { WebSocket } from 'ws';
                                 ~~~~

node_modules/it-ws/dist/src/web-socket.d.ts:1:23 - error TS7016: Could not find a declaration file for module 'ws'. '/Users/horizon/Desktop/test/node_modules/ws/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`

1 import WebSocket from 'ws';
                        ~~~~
```